### PR TITLE
Error handling improvements for PHP 7 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,13 @@
 var Exception = require('./src/Error/Exception'),
     PHPError = require('./src/Error/PHPError'),
     PHPFatalError = require('./src/Error/PHPFatalError'),
-    PHPParseError = require('./src/Error/PHPParseError');
+    PHPParseError = require('./src/Error/PHPParseError'),
+    Translator = require('./src/Translator');
 
 module.exports = {
     Exception: Exception,
     PHPError: PHPError,
     PHPFatalError: PHPFatalError,
-    PHPParseError: PHPParseError
+    PHPParseError: PHPParseError,
+    Translator: Translator
 };

--- a/src/Error/PHPError.js
+++ b/src/Error/PHPError.js
@@ -13,20 +13,88 @@ var _ = require('microdash'),
     util = require('util'),
     Exception = require('./Exception');
 
-function PHPError(level, message) {
-    Exception.call(this, 'PHP ' + level + ': ' + message);
+/**
+ * Represents any kind of PHP error (warning, notice, parse, fatal)
+ *
+ * @param {string} level
+ * @param {string} message
+ * @param {string|null=} filePath
+ * @param {number|null=} lineNumber
+ * @constructor
+ */
+function PHPError(level, message, filePath, lineNumber) {
+    // Form a readable string for the error, for when the library is used outside PHPCore
+    // (as inside PHPCore, these errors will be intercepted and inspected using the getter methods below)
+    Exception.call(
+        this,
+        'PHP ' + level + ': ' + message + ' in ' + (filePath || '(unknown)') + ' on line ' + (lineNumber || '(unknown)')
+    );
+
+    /**
+     * @type {string|null} Path to the file the error occurred in
+     */
+    this.filePath = filePath;
+    /**
+     * @type {string}
+     */
+    this.level = level;
+    /**
+     * @type {number|null} Which line the error occurred on, if known
+     */
+    this.lineNumber = lineNumber;
+    /**
+     * @type {string} Original message without level prefix
+     */
+    this.originalMessage = message;
 }
 
 util.inherits(PHPError, Exception);
 
 _.extend(PHPError, {
     E_DEPRECATED: 'Deprecated',
-    E_ERROR: 'Error',
-    E_FATAL: 'Fatal error',
+    E_ERROR: 'Fatal error',
     E_NOTICE: 'Notice',
     E_PARSE: 'Parse error',
     E_STRICT: 'Strict standards',
     E_WARNING: 'Warning'
+});
+
+_.extend(PHPError.prototype, {
+    /**
+     * Fetches the PHP module file the error occurred in if known, otherwise returns null
+     *
+     * @return {string|null}
+     */
+    getFilePath: function () {
+        return this.filePath;
+    },
+
+    /**
+     * Fetches the level of the error (E_DEPRECATED, E_WARNING etc.)
+     *
+     * @return {string}
+     */
+    getLevel: function () {
+        return this.level;
+    },
+
+    /**
+     * Fetches the line the error occurred on if known, otherwise returns null
+     *
+     * @return {number|null}
+     */
+    getLineNumber: function () {
+        return this.lineNumber;
+    },
+
+    /**
+     * Fetches the message for the error, without the level prefix
+     *
+     * @return {string}
+     */
+    getMessage: function () {
+        return this.originalMessage;
+    }
 });
 
 module.exports = PHPError;

--- a/src/Error/PHPFatalError.js
+++ b/src/Error/PHPFatalError.js
@@ -9,80 +9,21 @@
 
 'use strict';
 
-var MESSAGE_PREFIXES = {
-        0: '${message}',
-        1: 'Unsupported operand types',
-        2: 'Call to undefined function ${name}()',
-        3: 'Class \'${name}\' not found',
-        4: 'Call to undefined method ${className}::${methodName}()',
-        5: '\'goto\' into loop or switch statement is disallowed',
-        6: '${name}() must take exactly 1 argument',
-        7: 'Class name must be a valid object or a string',
-        8: 'Access to undeclared static property: ${className}::$${propertyName}',
-        9: 'Call to undefined method ${className}::${methodName}()',
-        10: 'Cannot access ${className}:: when no class scope is active',
-        11: 'Undefined constant \'${name}\'',
-        12: 'Uncaught exception \'${name}\'',
-        13: 'Cannot access ${visibility} property ${className}::$${propertyName}',
-        14: 'Function name must be a string',
-        15: 'Undefined class constant \'${name}\'',
-        16: 'Interfaces may not include member variables',
-        17: 'Interface function ${className}::${methodName}() cannot contain body',
-        18: 'Cannot use ${source} as ${alias} because the name is already in use',
-        19: 'Call to a member function ${name}() on a non-object',
-        20: 'instanceof expects an object instance, constant given',
-        21: 'Cannot use object of type ${actual} as ${expected}',
-        22: 'Using $this when not in object context',
-        23: '\'${operator}\' operator accepts only positive numbers',
-        24: 'Cannot break/continue ${levels} level${suffix}',
-        25: 'Only variables can be passed by reference',
-        26: 'Attempt to unset static property ${className}::$${propertyName}',
-        27: 'Cannot access parent:: when current class scope has no parent',
-        28: '\'goto\' to undefined label \'${label}\'',
-        29: 'Label \'${label}\' already defined'
-    },
-    _ = require('microdash'),
-    templateString = require('template-string'),
-    util = require('util'),
+var util = require('util'),
     PHPError = require('./PHPError');
 
-function PHPFatalError(code, variables) {
-    PHPError.call(this, PHPError.E_FATAL, templateString(MESSAGE_PREFIXES[code], variables));
+/**
+ * Represents a fatal PHP error
+ *
+ * @param {string} message
+ * @param {string|null} filePath
+ * @param {number|null} lineNumber
+ * @constructor
+ */
+function PHPFatalError(message, filePath, lineNumber) {
+    PHPError.call(this, PHPError.E_ERROR, message, filePath, lineNumber);
 }
 
 util.inherits(PHPFatalError, PHPError);
-
-_.extend(PHPFatalError, {
-    GENERIC: 0,
-    UNSUPPORTED_OPERAND_TYPES: 1,
-    CALL_TO_UNDEFINED_FUNCTION: 2,
-    CLASS_NOT_FOUND: 3,
-    UNDEFINED_METHOD: 4,
-    GOTO_DISALLOWED: 5,
-    EXPECT_EXACTLY_1_ARG: 6,
-    CLASS_NAME_NOT_VALID: 7,
-    UNDECLARED_STATIC_PROPERTY: 8,
-    CALL_TO_UNDEFINED_METHOD: 9,
-    CANNOT_ACCESS_WHEN_NO_ACTIVE_CLASS: 10,
-    UNDEFINED_CONSTANT: 11,
-    UNCAUGHT_EXCEPTION: 12,
-    CANNOT_ACCESS_PROPERTY: 13,
-    FUNCTION_NAME_MUST_BE_STRING: 14,
-    UNDEFINED_CLASS_CONSTANT: 15,
-    INTERFACE_PROPERTY_NOT_ALLOWED: 16,
-    INTERFACE_METHOD_BODY_NOT_ALLOWED: 17,
-    NAME_ALREADY_IN_USE: 18,
-    NON_OBJECT_METHOD_CALL: 19,
-    INSTANCEOF_EXPECTS_OBJECT: 20,
-    CANNOT_USE_WRONG_TYPE_AS: 21,
-    USED_THIS_OUTSIDE_OBJECT_CONTEXT: 22,
-    OPERATOR_REQUIRES_POSITIVE_NUMBER: 23,
-    CANNOT_BREAK_OR_CONTINUE: 24,
-    ONLY_VARIABLES_BY_REFERENCE: 25,
-    CANNOT_UNSET_STATIC_PROPERTY: 26,
-    NO_PARENT_CLASS: 27,
-    GOTO_TO_UNDEFINED_LABEL: 28,
-    LABEL_ALREADY_DEFINED: 29
-});
 
 module.exports = PHPFatalError;

--- a/src/Error/PHPParseError.js
+++ b/src/Error/PHPParseError.js
@@ -9,22 +9,21 @@
 
 'use strict';
 
-var _ = require('microdash'),
-    templateString = require('template-string'),
-    util = require('util'),
-    PHPError = require('./PHPError'),
-    MESSAGE_PREFIXES = {
-        1: 'syntax error, unexpected ${what} in ${file} on line ${line}'
-    };
+var util = require('util'),
+    PHPError = require('./PHPError');
 
-function PHPParseError(code, variables) {
-    PHPError.call(this, PHPError.E_PARSE, templateString(MESSAGE_PREFIXES[code], variables));
+/**
+ * Represents a PHP parse error
+ *
+ * @param {string} message
+ * @param {string|null} filePath
+ * @param {number|null} lineNumber
+ * @constructor
+ */
+function PHPParseError(message, filePath, lineNumber) {
+    PHPError.call(this, PHPError.E_PARSE, message, filePath, lineNumber);
 }
 
 util.inherits(PHPParseError, PHPError);
-
-_.extend(PHPParseError, {
-    SYNTAX_UNEXPECTED: 1
-});
 
 module.exports = PHPParseError;

--- a/src/Translator.js
+++ b/src/Translator.js
@@ -1,0 +1,118 @@
+/*
+ * PHPCommon - Common tools for PHP environments
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcommon/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcommon/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash'),
+    DEFAULT_LOCALE = 'en_GB',
+    hasOwn = {}.hasOwnProperty,
+    templateString = require('template-string');
+
+/**
+ * Stores translations for internal strings in different locales
+ *
+ * @constructor
+ */
+function Translator() {
+    /**
+     * @type {Object.<string, Object.<string, string>>}
+     */
+    this.cataloguesByLocale = {};
+    /**
+     * @type {string}
+     */
+    this.currentLocale = DEFAULT_LOCALE;
+}
+
+_.extend(Translator.prototype, {
+    /**
+     * Adds a translation for a specific key within a given locale
+     *
+     * @param {string} locale e.g. en_GB
+     * @param {string} key e.g. error.my_error.my_sub_msg
+     * @param {string} translation
+     */
+    addTranslation: function (locale, key, translation) {
+        var translator = this;
+
+        if (!hasOwn.call(translator.cataloguesByLocale, locale)) {
+            translator.cataloguesByLocale[locale] = {};
+        }
+
+        this.cataloguesByLocale[locale][key] = translation;
+    },
+
+    /**
+     * Adds multiple translations, potentially across multiple locales' catalogues
+     *
+     * @param {Object.<string, object>} structure
+     */
+    addTranslations: function (structure) {
+        var translator = this;
+
+        function add(locale, keyParts, data) {
+            if (_.isPlainObject(data)) {
+                _.forOwn(data, function (data, keyPart) {
+                    add(locale, keyParts.concat([keyPart]), data);
+                });
+            } else {
+                translator.addTranslation(locale, keyParts.join('.'), data);
+            }
+        }
+
+        _.forOwn(structure, function (data, locale) {
+            add(locale, [], data);
+        });
+    },
+
+    /**
+     * Selects which catalogue of messages should be used for translation by locale
+     *
+     * @param {string} locale
+     */
+    setLocale: function (locale) {
+        this.currentLocale = locale;
+    },
+
+    /**
+     * Translates the given key for the current locale (falling back to the default locale if not defined)
+     * and fills in any placeholders with the given variables
+     *
+     * @param {string} key
+     * @param {Object.<string, string>=} placeholderVariables
+     * @returns {string}
+     * @throws {Error} When the translation is not defined for the current nor fallback locales
+     */
+    translate: function (key, placeholderVariables) {
+        var translation,
+            translator = this;
+
+        if (hasOwn.call(translator.cataloguesByLocale, translator.currentLocale) &&
+            hasOwn.call(translator.cataloguesByLocale[translator.currentLocale], key)
+        ) {
+            // The translation is defined for the current locale - use it
+            translation = translator.cataloguesByLocale[translator.currentLocale][key];
+        } else {
+            // Fall back to the default locale's catalogue
+
+            if (!hasOwn.call(translator.cataloguesByLocale[DEFAULT_LOCALE], key)) {
+                throw new Error(
+                    'Translation "' + key + '" is not defined for current locale "' + translator.currentLocale +
+                    '" nor the default locale "' + DEFAULT_LOCALE + '"'
+                );
+            }
+
+            translation = translator.cataloguesByLocale[DEFAULT_LOCALE][key];
+        }
+
+        return templateString(translation, placeholderVariables);
+    }
+});
+
+module.exports = Translator;

--- a/test/Error/PHPErrorTest.js
+++ b/test/Error/PHPErrorTest.js
@@ -15,48 +15,74 @@ var expect = require('chai').expect,
 
 describe('PHPError', function () {
     it('should set the correct message for a deprecation warning', function () {
-        var error = new PHPError(PHPError.E_DEPRECATED, 'Going soon');
+        var error = new PHPError(PHPError.E_DEPRECATED, 'Going soon', '/my/module.php', 123);
 
-        expect(error.message).to.equal('PHP Deprecated: Going soon');
+        expect(error.message).to.equal('PHP Deprecated: Going soon in /my/module.php on line 123');
     });
 
     it('should set the correct message for a fatal error', function () {
-        var error = new PHPError(PHPError.E_FATAL, 'Nice seein\' ya');
+        var error = new PHPError(PHPError.E_ERROR, 'Nice seein\' ya', '/my/module.php', 123);
 
-        expect(error.message).to.equal('PHP Fatal error: Nice seein\' ya');
-    });
-
-    it('should set the correct message for an error', function () {
-        var error = new PHPError(PHPError.E_ERROR, 'Oh, bang');
-
-        expect(error.message).to.equal('PHP Error: Oh, bang');
+        expect(error.message).to.equal('PHP Fatal error: Nice seein\' ya in /my/module.php on line 123');
     });
 
     it('should set the correct message for a parse error', function () {
-        var error = new PHPError(PHPError.E_PARSE, 'What does that even say?');
+        var error = new PHPError(PHPError.E_PARSE, 'What does that even say?', '/my/module.php', 123);
 
-        expect(error.message).to.equal('PHP Parse error: What does that even say?');
+        expect(error.message).to.equal('PHP Parse error: What does that even say? in /my/module.php on line 123');
     });
 
     it('should set the correct message for a notice', function () {
-        var error = new PHPError(PHPError.E_NOTICE, 'No rave music after 10pm');
+        var error = new PHPError(PHPError.E_NOTICE, 'No rave music after 10pm', '/my/module.php', 123);
 
-        expect(error.message).to.equal('PHP Notice: No rave music after 10pm');
+        expect(error.message).to.equal('PHP Notice: No rave music after 10pm in /my/module.php on line 123');
     });
 
     it('should set the correct message for a strict standards warning', function () {
-        var error = new PHPError(PHPError.E_STRICT, 'Being a bit picky, but');
+        var error = new PHPError(PHPError.E_STRICT, 'Being a bit picky, but', '/my/module.php', 123);
 
-        expect(error.message).to.equal('PHP Strict standards: Being a bit picky, but');
+        expect(error.message).to.equal('PHP Strict standards: Being a bit picky, but in /my/module.php on line 123');
     });
 
     it('should set the correct message for a warning', function () {
+        var error = new PHPError(PHPError.E_WARNING, 'Oh dear', '/my/module.php', 123);
+
+        expect(error.message).to.equal('PHP Warning: Oh dear in /my/module.php on line 123');
+    });
+
+    it('should set the correct message when file and line are omitted', function () {
         var error = new PHPError(PHPError.E_WARNING, 'Oh dear');
 
-        expect(error.message).to.equal('PHP Warning: Oh dear');
+        expect(error.message).to.equal('PHP Warning: Oh dear in (unknown) on line (unknown)');
     });
 
     it('should extend the Exception class', function () {
         expect(new PHPError()).to.be.an.instanceOf(Exception);
+    });
+
+    it('should set the correct level', function () {
+        var error = new PHPError(PHPError.E_WARNING, 'Oh dear', '/my/module.php', 123);
+
+        expect(error.getLevel()).to.equal(PHPError.E_WARNING);
+    });
+
+    it('should set the correct original message', function () {
+        var error = new PHPError(PHPError.E_WARNING, 'Oh dear', '/my/module.php', 123);
+
+        // Note that file and line information should not be included,
+        // as it will be fetched separately via the .getFilePath() and .getLineNumber() methods
+        expect(error.getMessage()).to.equal('Oh dear');
+    });
+
+    it('should set the correct file path', function () {
+        var error = new PHPError(PHPError.E_WARNING, 'Oh dear', '/my/module.php', 123);
+
+        expect(error.getFilePath()).to.equal('/my/module.php');
+    });
+
+    it('should set the correct line number', function () {
+        var error = new PHPError(PHPError.E_WARNING, 'Oh dear', '/my/module.php', 123);
+
+        expect(error.getLineNumber()).to.equal(123);
     });
 });

--- a/test/Error/PHPFatalErrorTest.js
+++ b/test/Error/PHPFatalErrorTest.js
@@ -10,22 +10,39 @@
 'use strict';
 
 var expect = require('chai').expect,
+    PHPError = require('../../src/Error/PHPError'),
     PHPFatalError = require('../../src/Error/PHPFatalError');
 
 describe('PHPFatalError', function () {
-    it('should set the correct message for a generic error', function () {
-        var error = new PHPFatalError(PHPFatalError.GENERIC, {
-            message: 'My generic message here'
-        });
+    var error;
 
-        expect(error.message).to.equal('PHP Fatal error: My generic message here');
+    beforeEach(function () {
+        error = new PHPFatalError('Oh dear!', '/path/to/my/module.php', 432);
     });
 
-    it('should set the correct message for a call to undefined function error', function () {
-        var error = new PHPFatalError(PHPFatalError.CALL_TO_UNDEFINED_FUNCTION, {
-            name: 'aMissingFunction'
-        });
+    it('should set the correct level', function () {
+        expect(error.getLevel()).to.equal(PHPError.E_ERROR);
+    });
 
-        expect(error.message).to.equal('PHP Fatal error: Call to undefined function aMissingFunction()');
+    it('should set the correct message', function () {
+        expect(error.message).to.equal('PHP Fatal error: Oh dear! in /path/to/my/module.php on line 432');
+    });
+
+    it('should set the correct original message', function () {
+        // Note that file and line information should not be included,
+        // as it will be fetched separately via the .getFilePath() and .getLineNumber() methods
+        expect(error.getMessage()).to.equal('Oh dear!');
+    });
+
+    it('should set the correct file path', function () {
+        expect(error.getFilePath()).to.equal('/path/to/my/module.php');
+    });
+
+    it('should set the correct line number', function () {
+        expect(error.getLineNumber()).to.equal(432);
+    });
+
+    it('should extend the PHPError class', function () {
+        expect(error).to.be.an.instanceOf(PHPError);
     });
 });

--- a/test/Error/PHPParseErrorTest.js
+++ b/test/Error/PHPParseErrorTest.js
@@ -10,16 +10,41 @@
 'use strict';
 
 var expect = require('chai').expect,
+    PHPError = require('../../src/Error/PHPError'),
     PHPParseError = require('../../src/Error/PHPParseError');
 
 describe('PHPParseError', function () {
-    it('should set the correct message for an unexpected syntax error', function () {
-        var error = new PHPParseError(PHPParseError.SYNTAX_UNEXPECTED, {
-            what: '<something>',
-            file: 'app.php',
-            line: 21
-        });
+    var error;
 
-        expect(error.message).to.equal('PHP Parse error: syntax error, unexpected <something> in app.php on line 21');
+    beforeEach(function () {
+        error = new PHPParseError('syntax error, unexpected <something>', '/path/to/your/module.php', 21);
+    });
+
+    it('should set the correct level', function () {
+        expect(error.getLevel()).to.equal(PHPError.E_PARSE);
+    });
+
+    it('should set the correct message', function () {
+        expect(error.message).to.equal(
+            'PHP Parse error: syntax error, unexpected <something> in /path/to/your/module.php on line 21'
+        );
+    });
+
+    it('should set the correct original message', function () {
+        // Note that file and line information should not be included,
+        // as it will be fetched separately via the .getFilePath() and .getLineNumber() methods
+        expect(error.getMessage()).to.equal('syntax error, unexpected <something>');
+    });
+
+    it('should set the correct file path', function () {
+        expect(error.getFilePath()).to.equal('/path/to/your/module.php');
+    });
+
+    it('should set the correct line number', function () {
+        expect(error.getLineNumber()).to.equal(21);
+    });
+
+    it('should extend the PHPError class', function () {
+        expect(error).to.be.an.instanceOf(PHPError);
     });
 });

--- a/test/TranslatorTest.js
+++ b/test/TranslatorTest.js
@@ -1,0 +1,84 @@
+/*
+ * PHPCommon - Common tools for PHP environments
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcommon/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcommon/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Translator = require('../src/Translator');
+
+describe('Translator', function () {
+    var translator;
+
+    beforeEach(function () {
+        translator = new Translator();
+
+        translator.addTranslation('en_GB', 'their_name', 'What colour would you like ${name}?');
+        translator.addTranslation('en_US', 'their_name', 'What color would you like ${name}?');
+    });
+
+    describe('addTranslation()', function () {
+        it('should be able to override an existing translation for a given locale', function () {
+            translator.addTranslation('en_GB', 'their_name', 'My different text ${name}!');
+
+            expect(translator.translate('their_name', {name: 'Martha'})).to.equal('My different text Martha!');
+        });
+    });
+
+    describe('addTranslations()', function () {
+        it('should be able to add translations with dotted key at the top level', function () {
+            translator.setLocale('en_US');
+
+            translator.addTranslations({
+                'en_US': {
+                    'my_translation': 'My text is "${what}".'
+                }
+            });
+
+            expect(translator.translate('my_translation', {what: 'here!'})).to.equal('My text is "here!".');
+        });
+
+        it('should be able to add translations with nested object structure', function () {
+            translator.addTranslations({
+                'en_GB': {
+                    'my': {
+                        'sub': {
+                            'stuff': {
+                                'text': 'Here is "${what}"'
+                            }
+                        }
+                    }
+                }
+            });
+
+            expect(translator.translate('my.sub.stuff.text', {what: 'my text!'})).to.equal('Here is "my text!"');
+        });
+    });
+
+    describe('translate()', function () {
+        it('should translate a string added for the fallback locale when using that same locale', function () {
+            expect(translator.translate('their_name', {name: 'Fred'})).to.equal('What colour would you like Fred?');
+        });
+
+        it('should translate a string added for a different locale when using that locale', function () {
+            translator.setLocale('en_US');
+
+            expect(translator.translate('their_name', {name: 'Fred'})).to.equal('What color would you like Fred?');
+        });
+
+        it('should throw when the translation does not exist for the current nor fallback locales', function () {
+            translator.setLocale('en_US');
+
+            expect(function () {
+                translator.translate('undefined_thing');
+            }).to.throw(
+                'Translation "undefined_thing" is not defined for current locale "en_US" nor the default locale "en_GB"'
+            );
+        });
+    });
+});

--- a/test/apiTest.js
+++ b/test/apiTest.js
@@ -13,7 +13,8 @@ var expect = require('chai').expect,
     phpCommon = require('..'),
     PHPError = require('../src/Error/PHPError'),
     PHPFatalError = require('../src/Error/PHPFatalError'),
-    PHPParseError = require('../src/Error/PHPParseError');
+    PHPParseError = require('../src/Error/PHPParseError'),
+    Translator = require('../src/Translator');
 
 describe('Public API', function () {
     it('should export the PHPError class', function () {
@@ -26,5 +27,9 @@ describe('Public API', function () {
 
     it('should export the PHPParseError class', function () {
         expect(phpCommon.PHPParseError).to.equal(PHPParseError);
+    });
+
+    it('should export the Translator class', function () {
+        expect(phpCommon.Translator).to.equal(Translator);
     });
 });


### PR DESCRIPTION
- Adds `Translator` to support i18n translations for PHP messages (errors, notices, warnings etc.)
- Makes `PHPError`, `PHPFatalError` and `PHPParseError` more generic